### PR TITLE
Add logging to bind9

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,3 +70,8 @@ default['bind']['options'] = Array.new
 default['bind']['zones'] = Array.new
 default['bind']['zonetype'] = "slave"
 default['bind']['zonesource'] = nil
+
+# This attribute enable logging
+default['bind']['enable_log'] = false
+default['bind']['log_file'] = "/var/log/bind9/query.log"
+default['bind']['log_options'] = Array.new

--- a/templates/default/named.options.erb
+++ b/templates/default/named.options.erb
@@ -22,3 +22,17 @@ options {
   <%= option_line %>
   <% end -%>
 };
+
+<% if node['bind']['enable_log'] %>
+logging {
+  channel b_query {
+    file "<%= node['bind']['log_file'] %>" versions 2 size 1m;
+    print-time yes;
+    severity info;
+     <% node['bind']['log_options'].each do |option_line| -%>
+    <%= option_line %>
+    <% end -%>
+  };
+  category queries { b_query; };
+};
+<% end %>


### PR DESCRIPTION
Hi,
I add logging to bind config. It's usefull in some case like http://wiki.debuntu.org/wiki/Munin/Bind9_Plugin

I thought about use data_bag and add so many logs, as people want. But I am not sure that it necessary.

Please check and add that changes.
