### PR TITLE
Don't try to use bind databag if not specified

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,8 +24,12 @@ all_zones = Array.new
 if Chef::Config['solo'] && !node['bind']['allow_solo_search']
   Chef::Log.warn("This recipe uses search. Chef Solo does not support search.")
 else
-  search(:bind, "role:#{node['bind']['acl-role']}") do |acl|
-    node.default['bind']['acls'] << acl
+  begin 
+    search(:bind, "role:#{node['bind']['acl-role']}") do |acl|
+      node.default['bind']['acls'] << acl
+    end
+  rescue
+    Chef::Log.warn("bind databag not found, assuming ACL is empty.")
   end
 end
 


### PR DESCRIPTION
Hi !

I used this cookbook without specifiying bind databag, but default recipe still tries to load items from it : 

```
 Net::HTTPServerException
 ------------------------
 404 "Object Not Found"

 Cookbook Trace:
 ---------------
   /var/chef/cache/cookbooks/bind/recipes/default.rb:28:in `from_file'
```

Is 'bind' databag really mandatory (it seems not) ?

To fix this I just throw an execption when collecting databag values in default recipe, it's just an idea ... take it or not :-P.

Regards
