### PR TITLE
Correct quoting on log file rotation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -83,8 +83,8 @@ default['bind']['zonesource'] = nil
 
 # This attribute enable logging
 default['bind']['enable_log'] = false
-default['bind']['log_file_versions'] = 10
-default['bind']['log_file_size'] = '500m'
+default['bind']['log_file_versions'] = 2
+default['bind']['log_file_size'] = '1m'
 default['bind']['log_file'] = '/var/log/bind9/query.log'
 default['bind']['log_options'] = []
 

--- a/templates/default/named.options.erb
+++ b/templates/default/named.options.erb
@@ -26,7 +26,7 @@ options {
 <% if node['bind']['enable_log'] %>
 logging {
   channel b_query {
-    file "<%= node['bind']['log_file'] %>" versions <%= node['bind']['log_file_versions'] %> size <%= node['bind']['log_file_size'] %>:
+    file "<%= node['bind']['log_file'] %>" versions <%= node['bind']['log_file_versions'] %> size <%= node['bind']['log_file_size'] %>;
     print-time yes;
     severity info;
     <% node['bind']['log_options'].each do |option_line| -%>


### PR DESCRIPTION
Two small fixes
- Quoting is wrong for the previous PR ( https://github.com/atomic-penguin/cookbook-bind/pull/13 ) and results in BIND not being able to start
- Restore previous defaults for query log size and rotation since 10*500MB means 5GB of unexpected logs
