### PR TITLE
Add source_file parameter to primary_zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the bind cookbook.
 
 ## Unreleased
 
+- Add source file parameter to `bind_primary_zone`
+
 ## 3.0.2 - *2021-10-13*
 
 - Convert `node['platform_version']` to a float for correct comparison

--- a/documentation/bind_primary_zone.md
+++ b/documentation/bind_primary_zone.md
@@ -2,7 +2,7 @@
 
 # bind_primary_zone
 
-This resource will copy a zone file from your current cookbook into the correct directory and add the zone as a master zone to your BIND configuration. The file should be named for the zone you wish to configure. For example to configure `example.com` the file should be in `files/default/example.com`
+This resource will copy a zone file from your current cookbook into the correct directory and add the zone as a master zone to your BIND configuration. The file should be named for the zone you wish to configure. For example to configure `example.com` the file should be in `files/default/example.com`, or set manually with `source_file`.
 
 This resource also supports setting the action to `:create_if_missing`. In this event the cookbook will only copy a zone file in place if it does not already exist. Once copied the cookbook will not touch the file again allowing it to be used for dynamic updates. However, please be aware that in the event of the server being rebuilt or the file being removed that the data has not been persisted anywhere.
 
@@ -22,6 +22,7 @@ This resource also supports setting the action to `:create_if_missing`. In this 
 | `options`     | Array  | `[]`                                                  | Array of option strings. Each option should be a valid BIND option minus the trailing semicolon.                           |
 | `view`        | String | Defaults to the value from the `bind_config` property | Name of the view to configure the zone in                                                                                  |
 | `zone_name`   | String |                                                       | The zone name of the zone. Used only if the name property does not match the zone name.                                    |
+| `source_file` | String |                                                       | Filename to source the zonefile from. Passed to `source` property of `cookbook_file`                                       |
 
 ## Examples
 

--- a/resources/primary_zone.rb
+++ b/resources/primary_zone.rb
@@ -15,6 +15,8 @@ property :view, String,
           description: 'Name of the view to configure the zone in'
 property :zone_name, String,
           description: 'The zone name of the zone'
+property :source_file, String,
+          description: 'File name to source the zonefile from'
 
 action :create do
   do_create action
@@ -29,9 +31,10 @@ action_class do
 
   def do_create(file_action)
     service_resource = find_service_resource
-    new_resource.zone_name = new_resource.file_name unless new_resource.zone_name
+    new_resource.zone_name ||= new_resource.file_name
 
     cookbook_file new_resource.name do
+      source new_resource.source_file
       path "#{service_resource.vardir}/primary/db.#{new_resource.name}"
       owner service_resource.run_user
       group service_resource.run_group

--- a/resources/secondary_zone.rb
+++ b/resources/secondary_zone.rb
@@ -10,7 +10,7 @@ property :view, String
 property :zone_name, String
 
 action :create do
-  new_resource.zone_name = new_resource.file_name unless new_resource.zone_name
+  new_resource.zone_name ||= new_resource.file_name
 
   config_template.variables[:secondary_zones] << SecondaryZone.new(
     new_resource.name,

--- a/spec/resources/primary_zone_spec.rb
+++ b/spec/resources/primary_zone_spec.rb
@@ -9,8 +9,12 @@ describe 'adding primary zones' do
 
   it 'uses the custom resource' do
     expect(chef_run).to create_bind_primary_zone('example.org')
-    expect(chef_run).to create_bind_primary_zone('example.org')
     expect(chef_run).to create_cookbook_file('example.org')
+
+    expect(chef_run).to create_bind_primary_zone('example.com')
+    expect(chef_run).to create_cookbook_file('example.com').with(
+      source: 'custom-example.com'
+    )
   end
 
   it 'will copy the zone file from the test cookbook' do

--- a/test/fixtures/cookbooks/bind_test/files/default/custom-example.com
+++ b/test/fixtures/cookbooks/bind_test/files/default/custom-example.com
@@ -1,0 +1,15 @@
+$TTL	86400 ; 24 hours could have been written as 24h or 1d
+; $TTL used for all RRs without explicit TTL value
+$ORIGIN example.com.
+@  1D  IN  SOA ns1.example.com. hostmaster.example.com. (
+			      2002022401 ; serial
+			      3H ; refresh
+			      15 ; retry
+			      1w ; expire
+			      3h ; nxdomain ttl
+			     )
+       IN  NS     ns1.example.com.
+       IN  NS     ns2.example.com.
+
+ns1    IN A 1.1.1.1
+ns2    IN A 1.1.1.2

--- a/test/fixtures/cookbooks/bind_test/recipes/spec_primary_zone.rb
+++ b/test/fixtures/cookbooks/bind_test/recipes/spec_primary_zone.rb
@@ -4,12 +4,14 @@ end
 
 bind_config 'default'
 
-bind_primary_zone 'example.com'
-
 bind_primary_zone 'example.org' do
   options [
     'allow-transfer { none; }',
   ]
+end
+
+bind_primary_zone 'example.com' do
+  source_file 'custom-example.com'
 end
 
 bind_primary_zone 'example.net' do


### PR DESCRIPTION
Signed-off-by: Robert Detjens <detjensrobert@osuosl.org>

# Description

This exposes the `cookbook_file` `source` parameter to allow for (existing) zonefiles to be managed by this cookbook if they do not match the expected filename pattern.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
