### PR TITLE
Add option to only create zone config whern zonefiles are externally managed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Lint & Unit Test'
+name: ci
 
 'on':
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the bind cookbook.
 
 ## Unreleased
 
+- add `:create_config_only` action to `bind_primary_zone`
+
 ## 3.1.0 - *2021-10-20*
 
 - Add source file parameter to `bind_primary_zone`

--- a/documentation/bind_primary_zone.md
+++ b/documentation/bind_primary_zone.md
@@ -6,12 +6,15 @@ This resource will copy a zone file from your current cookbook into the correct 
 
 This resource also supports setting the action to `:create_if_missing`. In this event the cookbook will only copy a zone file in place if it does not already exist. Once copied the cookbook will not touch the file again allowing it to be used for dynamic updates. However, please be aware that in the event of the server being rebuilt or the file being removed that the data has not been persisted anywhere.
 
+If the zone file is managed completely externally, `:create_config_only` will not manage the file at all and only create the zone entry in the BIND config.
+
 ## Actions
 
-| Action               | Description                                       |
-| -------------------- | ------------------------------------------------- |
-| `:create`            | Creates a BIND primary zone                       |
-| `:create_if_missing` | Creates a BIND primary zone, only if it's missing |
+| Action                | Description                                                                   |
+| --------------------- | ----------------------------------------------------------------------------- |
+| `:create`             | Creates a BIND primary zone                                                   |
+| `:create_if_missing`  | Creates a BIND primary zone, only if it's missing                             |
+| `:create_config_only` | Creates the BIND config entry only and does not try to manage the file at all |
 
 ## Properties
 
@@ -27,12 +30,11 @@ This resource also supports setting the action to `:create_if_missing`. In this 
 ## Examples
 
 ```ruby
-bind_view 'internal' do
-  match_clients ['10.0.0.0/8']
-  options ['recursion yes']
-end
+# to load zone from files/db.example.org
+bind_primary_zone 'example.org'
 
-bind_view 'external' do
-  options ['recursion no']
+# or from custom file
+bind_primary_zone 'example.org' do
+  source_file 'other-example.org'
 end
 ```

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,6 +3,7 @@ driver:
   name: dokken
   privileged: true
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_license: accept
   cap_add:
     - SYS_PTRACE
     - SYS_ADMIN
@@ -76,4 +77,3 @@ platforms:
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro
       pid_one_command: /usr/lib/systemd/systemd
-...

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,6 +4,8 @@ driver:
 
 provisioner:
   name: chef_infra
+  multiple_converge: 2
+  enforce_idempotency: true
   deprecations_as_errors: true
   chef_license: accept-no-persist
   product_name: <%= ENV['CHEF_PRODUCT_NAME'] || 'chef' %>
@@ -18,6 +20,7 @@ platforms:
   - name: debian-11
   - name: centos-7
   - name: centos-8
+  - name: centos-stream-8
   - name: fedora-latest
 
 verifier:
@@ -63,3 +66,10 @@ suites:
         domain: ns1.example.net
         host_string: "ns1.example.net has address 1.1.1.1"
         linked: true
+  - name: zone-options
+    run_list:
+      - recipe[bind_test::zone_options]
+    verifier:
+      inputs:
+        domain: ns1.example.org
+        host_string: "ns1.example.org has address 1.1.1.1"

--- a/spec/resources/primary_zone_spec.rb
+++ b/spec/resources/primary_zone_spec.rb
@@ -15,6 +15,12 @@ describe 'adding primary zones' do
     expect(chef_run).to create_cookbook_file('example.com').with(
       source: 'custom-example.com'
     )
+
+    expect(chef_run).to create_if_missing_bind_primary_zone('example.net')
+    expect(chef_run).to create_if_missing_cookbook_file('example.net')
+
+    expect(chef_run).to create_config_only_bind_primary_zone('example.only')
+    expect(chef_run).to_not create_cookbook_file('example.only')
   end
 
   it 'will copy the zone file from the test cookbook' do

--- a/test/fixtures/cookbooks/bind_test/files/default/custom-example.net
+++ b/test/fixtures/cookbooks/bind_test/files/default/custom-example.net
@@ -1,15 +1,15 @@
 $TTL	86400 ; 24 hours could have been written as 24h or 1d
 ; $TTL used for all RRs without explicit TTL value
-$ORIGIN example.com.
-@  1D  IN  SOA ns1.example.com. hostmaster.example.com. (
+$ORIGIN example.net.
+@  1D  IN  SOA ns1.example.net. hostmaster.example.net. (
 			      2002022401 ; serial
 			      3H ; refresh
 			      15 ; retry
 			      1w ; expire
 			      3h ; nxdomain ttl
 			     )
-       IN  NS     ns1.example.com.
-       IN  NS     ns2.example.com.
+       IN  NS     ns1.example.net.
+       IN  NS     ns2.example.net.
 
 ns1    IN A 1.1.1.1
 ns2    IN A 1.1.1.2

--- a/test/fixtures/cookbooks/bind_test/recipes/spec_primary_zone.rb
+++ b/test/fixtures/cookbooks/bind_test/recipes/spec_primary_zone.rb
@@ -17,3 +17,7 @@ end
 bind_primary_zone 'example.net' do
   action :create_if_missing
 end
+
+bind_primary_zone 'example.only' do
+  action :create_config_only
+end

--- a/test/fixtures/cookbooks/bind_test/recipes/zone_options.rb
+++ b/test/fixtures/cookbooks/bind_test/recipes/zone_options.rb
@@ -1,0 +1,25 @@
+include_recipe 'bind_test::disable_resolved'
+
+bind_service 'default' do
+  action [:create, :start]
+end
+
+bind_config 'default'
+
+::Chef::DSL::Recipe.include BindCookbook::Helpers
+::Chef::Resource.include BindCookbook::Helpers
+
+# manage file externally
+cookbook_file "#{default_property_for(:vardir, false)}/primary/db.example.org" do
+  source 'example.org'
+  owner default_property_for(:run_user, false)
+  group default_property_for(:run_group, false)
+end
+
+bind_primary_zone 'example.org' do
+  action :create_config_only
+end
+
+bind_primary_zone 'example.net' do
+  source_file 'custom-example.net'
+end


### PR DESCRIPTION
# Description

Currently, this cookbook expects to manage the zonefiles either continually, or at initial setup via `:create_if_missing`. This PR adds an action to have `bind_primary_zone` not touch the zonefiles at all when they are externally managed outside of this cookbook.

## Issues Resolved

(none)

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.